### PR TITLE
Make sure $modx->resource is existing for logging

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -141,9 +141,11 @@ function __construct(modX &$modx, &$settings_cache, $options, $s3info = 0) {
  *  if $phpthumbDebug, also write the phpThumb debugmessages array
  */
 public function debugmsg($msg, $phpthumbDebug = FALSE) {
-	$logmsg = "[pThumb] Resource: {$this->modx->resource->get('id')} || Image: " .
-		(isset($this->input) ? $this->input : '(none)') .
-		($msg ? "\n$msg" : '');
+	if (!empty($this->modx->resource)) { 
+		$logmsg = "[pThumb] Resource: {$this->modx->resource->get('id')} || Image: " .
+			(isset($this->input) ? $this->input : '(none)') .
+			($msg ? "\n$msg" : '');
+	}
 	if ($phpthumbDebug && isset($this->phpThumb->debugmessages)) {
 		$logmsg .= ($this->config['useResizer'] ? "\nResizer" : "\nphpThumb") .
 			' debug output:' . substr(print_r($this->phpThumb->debugmessages, TRUE), 7, -2) .


### PR DESCRIPTION
When pThumb is used in the mgr context for example, the $modx->resource object is not always set, what leads to a fatal error (using get() on a non-object) in that case. The added check prevents this...
