### PR TITLE
Fixed GLOB_BRACE bug

### DIFF
--- a/core/components/phpthumbof/model/pthumbcachecleaner.class.php
+++ b/core/components/phpthumbof/model/pthumbcachecleaner.class.php
@@ -112,7 +112,7 @@ public function cleanCache() {
 		}
 	}
 	if ($cachepath['phpThumbOf']) {
-		if ( ! $cachefiles['phpThumbOf'] = glob("{$cachepath['phpThumbOf']}/*.{jp*g, png, gif}", GLOB_BRACE)) {
+		if ( ! $cachefiles['phpThumbOf'] = glob("{$cachepath['phpThumbOf']}/*.{jp*g,png,gif}", GLOB_BRACE)) {
 			$cachefiles['phpThumbOf'] = array();  // empty array if glob didn't find anything
 		}
 	}


### PR DESCRIPTION
glob fails to trim the split values resulting in only jp*g files being cleared from the cache.
