### PR TITLE
Respect &scale option in width/height attributes

### DIFF
--- a/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
+++ b/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
@@ -66,6 +66,11 @@ if (!empty($toPlaceholder) || $result['outputDims']) {
 		$output = '';
 	}
 	if ($result['outputDims']) {
+	    parse_str($options);
+	    if (isset($scale) && $scale > 1) {
+	        $result['width'] = floor($result['width'] / $scale);
+	        $result['height'] = floor($result['height'] / $scale);
+	    }
 		$output = "src=\"{$result['src']}\"" . ($result['width'] ? " width=\"{$result['width']}\" height=\"{$result['height']}\"" : '');
 	}
 }


### PR DESCRIPTION
Let's say we have an original image 1000x1000px and want to create a thumb at 250x250 with doubled pixels (retina resolution) so we set `&scale=2`.

If you set the `&dims=1` options to let pthumb add correct widht/height attributes, you'll get 500 and 500px for both attributes. Which are the correct values of the image, but since it should be a retina image those width/height attributes should be 250/250.

So I came up with this little solution for myself, where I check if `&scale` was set and calculate correct values.
