### PR TITLE
Suggestion for pThumb/Babel issue

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -60,7 +60,7 @@ function __construct(modX &$modx, &$settings_cache, $options, $s3info = 0) {
 			return;
 		}
 		$this->config['cacheNotWritable'] = false;
-		$cacheurl = rtrim($modx->getOption('phpthumbof.cache_url', null, $modx->getOption('base_url', null, MODX_BASE_URL), true), '/');
+		$cacheurl = rtrim($modx->getOption('phpthumbof.cache_url', null, $modx->getOption('base_url', null, MODX_BASE_URL), true)), '/';
 		$this->config['cachePathUrl'] = str_replace(MODX_BASE_PATH, "$cacheurl/", $this->config['cachePath']);
 		$this->config['remoteImagesCachePath'] = "{$this->config['assetsPath']}components/phpthumbof/cache/remote-images/";
 		$this->config['checkModTime'] = $modx->getOption('phpthumbof.check_mod_time', null, FALSE);


### PR DESCRIPTION
See: http://forums.modx.com/thread/88002/pthumb-and-multilanguage-site

At the moment an empty 'phpthumbof.cache_url' but existing system setting is not used (because skipEmpty is true in getOption). In Babel the 'base_url' setting is changed context specific, but the 'phpthumbof.cache_url' has to point to the MODX base url (empty 'phpthumbof.cache_url' setting). 

By moving the closing bracket of the rtrim and filling the setting with a space character the 'phpthumbof.cache_url' setting is used and the rtrim removes the space (before it don't because of the concatenated '/'). Changing the code this way should cause no side effect as changing skipEmpty to false in getOption would do.
