### PR TITLE
Serve S3 output thumbnails via CloudFront

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -159,4 +159,21 @@ $systemSettings[$ssIdx++]->fromArray(array (
 	'area' => 'Amazon S3',
 ), '', true, true);
 
+$systemSettings[$ssIdx] = $modx->newObject('modSystemSetting');
+$systemSettings[$ssIdx++]->fromArray(array (
+	'key' => 'pthumb.s3_output_cloudfront',
+	'value' => FALSE,
+	'xtype' => 'combo-boolean',
+	'namespace' => 'phpthumbof',
+	'area' => 'Amazon S3',
+), '', true, true);
+
+$systemSettings[$ssIdx] = $modx->newObject('modSystemSetting');
+$systemSettings[$ssIdx++]->fromArray(array (
+	'key' => 'pthumb.s3_output_cloudfront_url',
+	'xtype' => 'textfield',
+	'namespace' => 'phpthumbof',
+	'area' => 'Amazon S3',
+), '', true, true);
+
 return $systemSettings;

--- a/core/components/phpthumbof/lexicon/en/default.inc.php
+++ b/core/components/phpthumbof/lexicon/en/default.inc.php
@@ -76,5 +76,11 @@ $_lang['setting_pthumb.s3_multi_img_desc'] = 'Controls how pThumb checks for cac
 $_lang['setting_pthumb.s3_cache_path'] = 'S3 Cache Path Prefix';
 $_lang['setting_pthumb.s3_cache_path_desc'] = 'A subdirectory where all cached images will be stored in the S3 bucket(s).';
 
+$_lang['setting_pthumb.s3_output_cloudfront'] = 'S3 Output Via CloudFront';
+$_lang['setting_pthumb.s3_output_cloudfront_desc'] = 'Serve thumbnails via Amazon CloudFront instead of S3 bucket when using an S3 media source for output. Please also specify the CloudFront URL.';
+
+$_lang['setting_pthumb.s3_output_cloudfront_url'] = 'CloudFront URL';
+$_lang['setting_pthumb.s3_output_cloudfront__url_desc'] = 'The CloudFront URL used for serving the thumbnails. Ex: http://d111111abcdef8.cloudfront.net/';
+
 
 $_lang['prop_pthumb.debug_desc'] = 'Write debug messages to the MODX error log.';

--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -93,7 +93,12 @@ function __construct(modX &$modx, &$settings_cache, $options, $s3info = 0) {
 			else {  // initialize MS
 				$this->config["{$this->config['s3outKey']}_ok"] = true;
 				$s3properties = $s3obj->getPropertyList();
-				$this->config["{$this->config['s3outKey']}_url"] = $s3properties['url'];
+				$useCloudFront = $modx->getOption('pthumb.s3_output_cloudfront', null, false);
+				if ($useCloudFront) {
+					$this->config["{$this->config['s3outKey']}_url"] = $modx->getOption('pthumb.s3_output_cloudfront_url', null, $s3properties['url'], true); // fall-back to regular S3 url if CloudFront url is not set
+				} else {
+					$this->config["{$this->config['s3outKey']}_url"] = $s3properties['url'];
+				}
 				$s3obj->bucket = $s3properties['bucket'];
 				include_once MODX_CORE_PATH . 'model/aws/sdk.class.php';
 				define('AWS_KEY', $s3properties['key']);


### PR DESCRIPTION
We recently wanted to serve thumbnails via CloudFront for one of our websites, but it appears that pThumb currently only allows you to serve them directly from an S3 bucket. Therefore, we've added two new system settings which allow you to use CloudFront to serve the contents from the S3 output bucket.

In order to use it, you first need to create a new CloudFront web distribution for the S3 bucket in the AWS CloudFront console. Afterwards, you set the system setting _pthumb.s3_output_cloudfront_ to _true_ and point the _pthumb.s3_output_cloudfront_url_ setting to the URL of the CloudFront distribution in the MODX manager.

It would be nice if this could be included in a new release of pThumb. Please let us know if you need any further info!
