### PR TITLE
Add image aspect ratio to placeholders

### DIFF
--- a/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
+++ b/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
@@ -56,12 +56,14 @@ if (!empty($toPlaceholder) || $result['outputDims']) {
 	if ($result['width'] === '' && $result['file'] && $dims = getimagesize($result['file']) ) {
 			$result['width'] = $dims[0];
 			$result['height'] = $dims[1];
+			$result['ratio'] = round($dims[1] / $dims[0] * 100 ,1);
 	}
 	if (!empty($toPlaceholder)) {
 		$modx->setPlaceholders(array(
 			$toPlaceholder => $result['src'],
 			"$toPlaceholder.width" => $result['width'],
-			"$toPlaceholder.height" => $result['height']
+			"$toPlaceholder.height" => $result['height'],
+			"$toPlaceholder.ratio" => $result['ratio'],
 		));
 		$output = '';
 	}

--- a/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
+++ b/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
@@ -60,11 +60,11 @@ if (!empty($toPlaceholder) || $result['outputDims']) {
 	}
 	if (!empty($toPlaceholder)) {
 		$modx->setPlaceholders(array(
-			$toPlaceholder => $result['src'],
-			"$toPlaceholder.width" => $result['width'],
-			"$toPlaceholder.height" => $result['height'],
-			"$toPlaceholder.ratio" => $result['ratio'],
-		));
+			'src' => $result['src'],
+			'width' => $result['width'],
+			'height' => $result['height'],
+			'ratio' => $result['ratio'],
+		),$toPlaceholder.'.');
 		$output = '';
 	}
 	if ($result['outputDims']) {


### PR DESCRIPTION
Very helpful when using CSS solutions like: https://css-tricks.com/aspect-ratio-boxes/ to size dynamic width image containers and (or) lazy loading images. Example:

```
<html>
  <head>
    <style>
      .lazy-container {
        background-color: #C5C7C8;
        display: block;
        position: relative;
        height: 0;
        padding-top: 55.3%; //default
      }
      .lazy-container img {
        position: absolute;
        top: 0;
        left: 0;
        width: 100%;
        height: 100%;
      }
    </style>
  </head>
  <body>
    [[pthumb? &input=`[[*image]]` &options=`w=200` &toPlaceholder=`thumb`]]
    <div class="column" style="width: 20%;"> //can be any width
      <a href="#" class="lazy-container" style="padding-top: [[+thumb.ratio]]%;">
        <img class="lazy" data-src="[[+thumb]]"> //remove 'data-' to view image
      </a>
    </div>
  </body>
</html>
```

