### PR TITLE
Add option for file path prefix + add followlocation option to curl calls

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -53,6 +53,7 @@ function __construct(modX &$modx, &$settings_cache, $options, $s3info = 0) {
 			$this->config['cachePath'] = str_replace(array('[[+assets_path]]', '[[+base_path]]'), array($this->config['assetsPath'], MODX_BASE_PATH), $this->config['cachePath']);
 			$this->config['postfixPropertyHash'] = $modx->getOption('phpthumbof.postfix_property_hash', null, TRUE);
 		}
+		// Check if filePathPrefix is set in the pThumb snippet call options, and add it to the cachePath
 		if (isset($options['options'])) {
 			parse_str($options['options'], $parsedOptions);
 			if (isset($parsedOptions['filePathPrefix']) && !empty(trim($parsedOptions['filePathPrefix']))) {

--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -53,6 +53,12 @@ function __construct(modX &$modx, &$settings_cache, $options, $s3info = 0) {
 			$this->config['cachePath'] = str_replace(array('[[+assets_path]]', '[[+base_path]]'), array($this->config['assetsPath'], MODX_BASE_PATH), $this->config['cachePath']);
 			$this->config['postfixPropertyHash'] = $modx->getOption('phpthumbof.postfix_property_hash', null, TRUE);
 		}
+		if (isset($options['options'])) {
+			parse_str($options['options'], $parsedOptions);
+			if (isset($parsedOptions['filePathPrefix']) && !empty(trim($parsedOptions['filePathPrefix']))) {
+				$this->config['cachePath'] .= '/' . trim($parsedOptions['filePathPrefix'], '/') . '/';
+			}
+		}
 		$this->config['cachePath'] = rtrim(str_replace('//', '/', $this->config['cachePath']), '/') . '/';  // just in case
 		if (!is_writable($this->config['cachePath']) && !$modx->cacheManager->writeTree($this->config['cachePath'])) {  // check cache writability
 			$modx->log(modX::LOG_LEVEL_ERROR, "[pThumb] Cache path not writable: {$this->config['cachePath']}");
@@ -203,6 +209,7 @@ public function createThumbnail($src, $options) {
 			curl_setopt($curl, CURLOPT_NOBODY, true);
 			curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($curl, CURLOPT_FILETIME, true);
+			curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);
 
 			$result = curl_exec($curl);
 

--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -240,6 +240,7 @@ public function createThumbnail($src, $options) {
 			curl_setopt_array($ch, array(
 				CURLOPT_TIMEOUT	=> $this->config['remoteTimeout'],
 				CURLOPT_FILE => $fh,
+				CURLOPT_FOLLOWLOCATION => TRUE,
 				CURLOPT_FAILONERROR => TRUE
 			));
 			curl_exec($ch);  // download the file and store it in $fh


### PR DESCRIPTION
This PR fixes an issue, and adds a new feature.

Fix:
Add `CURLOPT_FOLLOWLOCATION` to remote image curl calls to allow curl to follow redirects (e.g. 301) on the remote url.
(fixes issue https://github.com/modxcms/pThumb/issues/56)

Feature:
Add `filePathPrefix` option to enable a prefix for the output image path. This option can be used in the snippet call options parameter, for example:
```[[pThumb?&input=`https://test.com/my-image.jpg`&options=`&w=300&h=300&filePathPrefix=[[*id]]`]]```

Which will result in adding the resource id in the output file path (using resource ID 1 as an example):
```assets/image-cache/1/my-image.jpg```

This is a welcome addition when handling large amounts of images where the source images are all in the same folder, which results in the image-cache folder having a lot of items, and it also makes pthumb slower with checking existing files and generating thumbnails since it has to navigate through this large folder.