### PR TITLE
Add Git Package Management build config

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -1,0 +1,134 @@
+{
+    "name": "pThumb",
+    "lowCaseName": "phpthumbof",
+    "description": "A better phpThumbOf",
+    "author": "MODx",
+    "version": "2.4.0",
+    "package": {
+        "menus": [],
+        "elements": {
+            "chunks": [],
+            "plugins": [{
+                "name": "phpThumbOfCacheManager",
+                "description": "Handles cache cleaning when clearing the Site Cache.",
+                "file": "phpthumbofcachemanager.plugin.php",
+                "events": [
+                    "OnSiteRefresh"
+                ]
+            }],
+            "snippets": [{
+                "name": "phpthumbof",
+                "description": "Identical to pthumb. Retained for backwards compatibility.\nDocumentation: https://github.com/oo12/phpThumbOf",
+                "file": "phpthumbof.snippet.php",
+                "properties": [{
+                    "name": "debug",
+                    "value": false,
+                    "description": "prop_pthumb.debug_desc",
+                    "type": "combo-boolean",
+                    "lexicon": "phpthumbof:default"
+                }]
+            },{
+                "name": "pthumb",
+                "description": "Identical to phpthumbof. Better for future compatibility.\nDocumentation: https://github.com/oo12/phpThumbOf",
+                "file": "phpthumbof.snippet.php",
+                "properties": [{
+                    "name": "debug",
+                    "value": false,
+                    "description": "prop_pthumb.debug_desc",
+                    "type": "combo-boolean",
+                    "lexicon": "phpthumbof:default"
+                }]
+            }]
+        },
+        "systemSettings": [{
+            "key": "phpthumbof.use_resizer",
+            "value": false,
+            "area": "Images",
+            "namespace": "",
+            "type": "combo-boolean"
+        },{
+            "key": "pthumb.global_defaults",
+            "area": "Images",
+            "namespace": ""
+        },{
+            "key": "phpthumbof.remote_timeout",
+            "value": 5,
+            "area": "Other",
+            "namespace": ""
+        },{
+            "key": "phpthumbof.postfix_property_hash",
+            "value": true,
+            "area": "Cache [phpThumbOf]",
+            "namespace": "",
+            "type": "combo-boolean"
+        },{
+            "key": "phpthumbof.cache_path",
+            "area": "Cache [phpThumbOf]",
+            "namespace": ""
+        },{
+            "key": "phpthumbof.cache_url",
+            "area": "Cache [common]",
+            "namespace": ""
+        },{
+            "key": "pthumb.clean_level",
+            "value": "0",
+            "area": "Cache [common]",
+            "namespace": ""
+        },{
+            "key": "pthumb.use_ptcache",
+            "value": false,
+            "area": "Cache [pThumb]",
+            "namespace": "",
+            "type": "combo-boolean"
+        },{
+            "key": "pthumb.ptcache_location",
+            "value": "assets/image-cache",
+            "area": "Cache [pThumb]",
+            "namespace": ""
+        },{
+            "key": "pthumb.ptcache_images_basedir",
+            "value": "assets",
+            "area": "Cache [pThumb]",
+            "namespace": ""
+        },{
+            "key": "phpthumbof.check_mod_time",
+            "value": false,
+            "area": "Cache [pThumb]",
+            "namespace": "",
+            "type": "combo-boolean"
+        },{
+            "key": "pthumb.s3_output",
+            "area": "Amazon S3",
+            "namespace": ""
+        },{
+            "key": "pthumb.s3_headers",
+            "area": "Amazon S3",
+            "namespace": "",
+            "type": "textarea"
+        },{
+            "key": "pthumb.s3_multi_img",
+            "value": false,
+            "area": "Amazon S3",
+            "namespace": "",
+            "type": "combo-boolean"
+        },{
+            "key": "pthumb.s3_cache_path",
+            "area": "Amazon S3",
+            "namespace": ""
+        }]
+    },
+    "dependencies": [{
+        "name": "resizer",
+        "version": ">=1.0.1"
+    }],
+    "build": {
+        "readme": "docs/readme.txt",
+        "license": "docs/license.txt",
+        "changelog": "docs/changelog.txt",
+        "resolver": {
+            "after": [
+                "phpthumbof.resolver.php"
+            ]
+        }
+    }
+}

--- a/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
+++ b/core/components/phpthumbof/elements/snippets/phpthumbof.snippet.php
@@ -42,7 +42,12 @@ $scriptProperties['debug'] = isset($debug) ? $debug : false;
 static $pt_settings = array();
 
 if (empty($pt_settings)) {
-	if (!$modx->loadClass('phpThumbOf', MODX_CORE_PATH . 'components/phpthumbof/model/', true, true)) {
+    $modelPath = $modx->getOption(
+        'phpthumbof.core_path',
+        null,
+        $modx->getOption('core_path', null, MODX_CORE_PATH) . 'components/phpthumbof/'
+    ) . 'model/';
+	if (!$modx->loadClass('phpThumbOf', $modelPath, true, true)) {
 		$modx->log(modX::LOG_LEVEL_ERROR, '[pThumb] Could not load phpThumbOf class.');
 		return $input;
 	}

--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -240,6 +240,7 @@ public function createThumbnail($src, $options) {
 			curl_setopt_array($ch, array(
 				CURLOPT_TIMEOUT	=> $this->config['remoteTimeout'],
 				CURLOPT_FILE => $fh,
+				CURLOPT_FOLLOWLOCATION => TRUE,
 				CURLOPT_FAILONERROR => TRUE
 			));
 			curl_exec($ch);  // download the file and store it in $fh

--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -240,7 +240,6 @@ public function createThumbnail($src, $options) {
 			curl_setopt_array($ch, array(
 				CURLOPT_TIMEOUT	=> $this->config['remoteTimeout'],
 				CURLOPT_FILE => $fh,
-				CURLOPT_FOLLOWLOCATION => TRUE,
 				CURLOPT_FAILONERROR => TRUE
 			));
 			curl_exec($ch);  // download the file and store it in $fh


### PR DESCRIPTION
This adds a GPM build config to be able to use pThumb with Git Package Management.
Also fixes the loadClass method call in phpthumbof snippet file to allow for custom core_path, as used by GPM.