### PR TITLE
Fix PHP warning : is_readable() open_basedir restriction in effect.

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -257,7 +257,7 @@ public function createThumbnail($src, $options) {
 		}
 	}
 	else {  // it's a local file
-		if (is_readable($src)) {  // if we've already got an existing file, keep going
+		if (!is_string(ini_get('open_basedir')) && is_readable($src)) {  // if we've already got an existing file, keep going
 			$file = $src;
 		}
 		else {  // otherwise prepend base_path and try again

--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -257,7 +257,20 @@ public function createThumbnail($src, $options) {
 		}
 	}
 	else {  // it's a local file
-		if (!is_string(ini_get('open_basedir')) && is_readable($src)) {  // if we've already got an existing file, keep going
+        // see if open_basedir is active - avoid calling is_readable in PHP >= 8.x
+        $openBasedirIniSetting = ini_get('open_basedir');
+        $isOpenBasedirSafe = true;
+        if (is_string($openBasedirIniSetting)) {
+            $isOpenBasedirSafe = false;
+            $openBasedirPaths = explode(":", $openBasedirIniSetting);
+            foreach($openBasedirPaths as $path) {
+                if (substr($src, 0, strlen($path)) == $path) {
+                    $isOpenBasedirSafe = true;
+                    break;
+                }
+            }
+        }
+        if ($isOpenBasedirSafe && is_readable($src)) {  // if we've already got an existing file, keep going
 			$file = $src;
 		}
 		else {  // otherwise prepend base_path and try again


### PR DESCRIPTION
The Modx error log is flooded with lines like the example below when using `open_basedir` settings in `php.ini`. (`open_basedir` is used as a security measure)

**PHP warning: is_readable(): open_basedir restriction in effect. File(/static/img/abc.webp) is not within the allowed path(s): (/var/sitename/htdocs:/tmp)**

Testing if `open_basedir` has a string prevents is_readable() being called with a path outside these limits. Thus avoiding these loglines.