### PR TITLE
Fix cache clearing for webp thumbnails

### DIFF
--- a/core/components/phpthumbof/model/phpthumbof.class.php
+++ b/core/components/phpthumbof/model/phpthumbof.class.php
@@ -72,7 +72,7 @@ function __construct(modX &$modx, &$settings_cache, $options, $s3info = 0) {
 		}
 		$this->config['s3multiImgGlobal'] = $s3info ? true : $modx->getOption('pthumb.s3_multi_img', null, false);
 		if ($s3info) {  // used by the cache cleaner class
-			$this->cacheimgRegex = '/^' . str_replace('/', '\/', $this->config['s3cachePath']) . '.+\.(?:[0-9a-f]{8}|[0-9a-f]{32})\.(?:jpe?g|png|gif)$/';  // for safety, only select images with a hash
+			$this->cacheimgRegex = '/^' . str_replace('/', '\/', $this->config['s3cachePath']) . '.+\.(?:[0-9a-f]{8}|[0-9a-f]{32})\.(?:jpe?g|png|gif|webp)$/';  // for safety, only select images with a hash
 		}
 	}
 	// these can't be cached

--- a/core/components/phpthumbof/model/pthumbcachecleaner.class.php
+++ b/core/components/phpthumbof/model/pthumbcachecleaner.class.php
@@ -100,10 +100,10 @@ public function cleanCache() {
 
 	$cachefiles = array();  // gather up cache files
 	foreach (array('pThumb', 'Remote Images') as $cachename) {
-		if (is_writeable($cachepath[$cachename])) {  // recurse through all subdirectories looking for jpeg, jpg, png and gif
+		if (is_writeable($cachepath[$cachename])) {  // recurse through all subdirectories looking for jpeg, jpg, png, gif and webp
 			$filter = new FilenameFilter(
 				new RecursiveDirectoryIterator($cachepath[$cachename], FilesystemIterator::SKIP_DOTS),
-				$cachename === 'pThumb' ? '/.+\.[0-9a-f]{8}\.(jpg|png|gif)$/' : '/\.(?:jpe?g|png|gif)$/i'  // for pThumb cache, only select images with what appears to be an 8-character hash
+				$cachename === 'pThumb' ? '/.+\.[0-9a-f]{8}\.(jpg|png|gif|webp)$/' : '/\.(?:jpe?g|png|gif|webp)$/i'  // for pThumb cache, only select images with what appears to be an 8-character hash
 			);
 			$cachefiles[$cachename] = array();
 			foreach(new RecursiveIteratorIterator($filter) as $file) {
@@ -112,7 +112,7 @@ public function cleanCache() {
 		}
 	}
 	if ($cachepath['phpThumbOf']) {
-		if ( ! $cachefiles['phpThumbOf'] = glob("{$cachepath['phpThumbOf']}/*.{jp*g,png,gif}", GLOB_BRACE)) {
+		if ( ! $cachefiles['phpThumbOf'] = glob("{$cachepath['phpThumbOf']}/*.{jp*g,png,gif,webp}", GLOB_BRACE)) {
 			$cachefiles['phpThumbOf'] = array();  // empty array if glob didn't find anything
 		}
 	}


### PR DESCRIPTION
Includes webp in the list of image extension that are used to collect image files in the cache cleaner.

Resolves #74